### PR TITLE
mention linux support and pi-apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,10 @@
 <!-- SPDX-License-Identifier: AGPL-3.0-only -->
 # Signal Unofficial (arm64)
 
-This repository is a fork of the official Signal destop with added support for arm64 on Windows and Apple Silicon you can download our [releases](https://github.com/dennisameling/Signal-Desktop/releases) for your device.
+This repository is a fork of the official Signal destop with added support for arm64 on Windows and Linux. You can download our [releases](https://github.com/dennisameling/Signal-Desktop/releases) for your device.
+
+On Linux ARM64, use the Pi-Apps store to keep it up to date.  
+[![badge](https://github.com/Botspot/pi-apps/blob/master/icons/badge.png?raw=true)](https://github.com/Botspot/pi-apps)  
 
 ## Ending support for Signal Unofficial on macOS
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This repository is a fork of the official Signal destop with added support for a
 
 On Linux ARM64, use the Pi-Apps store to keep it up to date.  
 [![badge](https://github.com/Botspot/pi-apps/blob/master/icons/badge.png?raw=true)](https://github.com/Botspot/pi-apps)  
+Pi-Apps will monitor this repo for new releases and will request to install new versions from here as they become available.  
 
 ## Ending support for Signal Unofficial on macOS
 


### PR DESCRIPTION
Hello, this PR makes it clearer on the README that your repo includes linux ARM64 builds. It also mentions how to keep Signal Unofficial updated on Linux, using the Pi-Apps store.
I am pleased to announce that Signal now live on [Pi-Apps](https://pi-apps.io) with [this commit.](https://github.com/Botspot/pi-apps/commit/64637cd7770af3e9a9c729f7656563413ea8f077)